### PR TITLE
Fix incorrect prop defaults in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Gallery usage:
 
 ### &lt;v-zoomer&gt; Props
 
-- `maxScale: number` - Maximum scale limit, default is 1;
-- `minScale: number` - Minimum scale limit, default is 5;
+- `maxScale: number` - Maximum scale limit, default is 5;
+- `minScale: number` - Minimum scale limit, default is 1;
 - `zoomed: out boolean` - Whether zoomed in (scale equals to 1). `out` means the prop is a child to parent one-way binding. So there must have a `.sync` modifier.
 - `pivot: 'cursor' | 'image-center'` - The pivot when zoom the content, default is `cursor`, can set to be `image-center`;
 - `limitTranslation: boolean` - Whether to limit the content into the container, default is `true`;


### PR DESCRIPTION
Per the source code, the default values for `min-scale` and `max-scale` in the docs appear to have been accidentally swapped.

https://github.com/jarvisniu/vue-zoomer/blob/14fdd84b0b9b19e34b67357f06460909c7e53f8b/src/vue-zoomer.vue#L29-L30

Thanks for publishing this component!