### PR TITLE
Remove CSS import from docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ Import:
 ```js
 import Vue from 'vue'
 import VueZoomer from 'vue-zoomer'
-import 'vue-zoomer/dist/vue-zoomer.css'
 
 Vue.use(VueZoomer)
 ```


### PR DESCRIPTION
Removes a reference to vue-zoomer.css, which is no longer in the package.